### PR TITLE
Add support for more Regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Emacs backup files
+*~
+*#
+.#*
+# Vim file artifacts
+.*.sw*
+# installed platform-specific binaries
+.DS_Store
+.project
+.vscode
+.gradle
+.idea

--- a/templates/fabric-ec2-client.template.yaml
+++ b/templates/fabric-ec2-client.template.yaml
@@ -85,9 +85,25 @@ Mappings:
   AWSRegionToAMI:
     us-east-1:
       HVM64: ami-0080e4c5bc078760e
+    eu-west-1:
+      HVM64: ami-031a03cb800ecb0d5
+    ap-southeast-1:
+      HVM64: ami-0d6c336fc1df6d884
+    ap-northeast-1:
+      HVM64: ami-0ee1410f0644c1cac
+    ap-northeast-2:
+      HVM64: ami-0a2778941dc6f2820
   AWSRegionToCertificateUrl:
     us-east-1:
       TLS: https://s3.amazonaws.com/us-east-1.managedblockchain/etc/managedblockchain-tls-chain.pem
+    ap-northeast-1:
+      TLS: https://s3.ap-northeast-1.amazonaws.com/ap-northeast-1.managedblockchain/etc/managedblockchain-tls-chain.pem
+    ap-northeast-2:
+      TLS: https://s3.ap-northeast-2.amazonaws.com/ap-northeast-2.managedblockchain/etc/managedblockchain-tls-chain.pem
+    ap-southeast-1:
+      TLS: https://s3.ap-southeast-1.amazonaws.com/ap-southeast-1.managedblockchain/etc/managedblockchain-tls-chain.pem
+    eu-west-1:
+      TLS: https://s3.eu-west-1.amazonaws.com/eu-west-1.managedblockchain/etc/managedblockchain-tls-chain.pem
   FrameworkVersionToPackageVersion:
     "1.2":
       DOCKERCOMPOSE: "1.20.0"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Added AMIs and TLS certificate location for all Regions that support Amazon Managed Blockchain.
AMIs are the standard Amazon Linux and not community versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
